### PR TITLE
Extract AWS Configuration into and Option

### DIFF
--- a/discovery_test.go
+++ b/discovery_test.go
@@ -89,6 +89,7 @@ func TestCanCallRequest(t *testing.T) {
 		SetAutomate(&mockAutomateAdapter{}),
 		SetLogger(&mockLogger{}),
 		SetTracer(&mockTracer{}),
+		SetFunction(&mockFunctionAdapter{}),
 	)
 	discover.Request("service->handler", types.Request{
 		Body: []byte(""),


### PR DESCRIPTION
**Breaking Change**

This removes the default AWS configuration for the `NewDiscovery`
function.  Instead, it allows the option to configure and AWS backend if
necessary.  Current projects would need to change the call from
`NewDiscovery()` to `NewDiscovery(WithAWSBackend())`.  In the future,
new backends can be added easily as `Option` s.  Also this maintains the
`Option` override functionality.