### PR TITLE
Separate API methods into X() and XWithOpts()

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ func main() {
 
   token, err := d.Queue("acme-prod.my-service->my-queue", types.Request{
     Body: []byte("{}"),
-  }, nil)
+  })
   ...
 }
 ```
@@ -69,7 +69,7 @@ func main() {
 d := discover.NewDiscovery()
 d.Request("my-namespace.users->create-user", types.Request{
   Body: []byte("{ \"hello\": \"world\" }"),
-}, opts)
+})
 ```
 
 ### Queue
@@ -78,10 +78,10 @@ d.Request("my-namespace.users->create-user", types.Request{
 d := discover.NewDiscovery()
 d.Queue("my-namespace.my-service->my-queue", types.Request{
   Body: jsonString,
-}, nil)
+})
 
 go func() {
-  messages, err := d.Listen("my-namespace.my-service->my-queue", opts)
+  messages, err := d.Listen("my-namespace.my-service->my-queue")
   for message := range message {
     log.Println(string(message.Body))
   }
@@ -123,8 +123,8 @@ Discover(signature *types.Signature) (*types.Service, error)
 type QueueAdapter interface {
 
 	// Queue a message, return a token or message id
-	Queue(service *types.Service, request types.Request, opts types.Options) (string, error)
-	Listen(service *types.Service, opts types.Options) (<-chan *types.Response, error)
+	QueueWithOpts(service *types.Service, request types.Request, opts types.Options) (string, error)
+	ListenWithOpts(service *types.Service, opts types.Options) (<-chan *types.Response, error)
 }
 ```
 
@@ -133,7 +133,7 @@ type QueueAdapter interface {
 ```golang
 // FunctionAdapter -
 type FunctionAdapter interface {
-	Call(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
+	CallWithOpts(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
 }
 ```
 
@@ -142,7 +142,7 @@ type FunctionAdapter interface {
 ```golang
 // AutomateAdapter -
 type AutomateAdapter interface {
-	Execute(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
+	ExecuteWithOpts(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
 }
 ```
 
@@ -151,8 +151,8 @@ type AutomateAdapter interface {
 ```golang
 // PubsubAdapter -
 type PubsubAdapter interface {
-	Publish(service *types.Service, request types.Request, opts types.Options) error
-	Subscribe(service *types.Service, opts types.Options) (<-chan *types.Response, error)
+	PublishWithOpts(service *types.Service, request types.Request, opts types.Options) error
+	SubscribeWithOpts(service *types.Service, opts types.Options) (<-chan *types.Response, error)
 }
 ```
 

--- a/discovery.go
+++ b/discovery.go
@@ -33,7 +33,7 @@ type Options struct {
 	TraceAdapter
 }
 
-// Option -
+// Option is a function that modifies the Options object
 type Option func(*Options)
 
 // SetQueue sets the given queue adapter to be used
@@ -85,7 +85,7 @@ func SetTracer(tracer TraceAdapter) Option {
 	}
 }
 
-// NewDiscovery -
+// NewDiscovery creates a new Discover object to communicate with the various services
 func NewDiscovery(opts ...Option) *Discover {
 	sess := session.Must(session.NewSession())
 	args := &Options{
@@ -113,7 +113,7 @@ func NewDiscovery(opts ...Option) *Discover {
 	}
 }
 
-// QueueAdapter -
+// QueueAdapter is an interface defining a Queue service
 type QueueAdapter interface {
 
 	// Queue a message, return a token or message id
@@ -121,33 +121,33 @@ type QueueAdapter interface {
 	Listen(service *types.Service, opts types.Options) (<-chan *types.Response, error)
 }
 
-// FunctionAdapter -
+// FunctionAdapter is an interface defining a Serverless Functions service
 type FunctionAdapter interface {
 	Call(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
 }
 
-// AutomateAdapter -
+// AutomateAdapter is an interface defining a System Management service
 type AutomateAdapter interface {
 	Execute(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
 }
 
-// PubsubAdapter -
+// PubsubAdapter is an interface defining a PubSub Messaging service
 type PubsubAdapter interface {
 	Publish(service *types.Service, request types.Request, opts types.Options) error
 	Subscribe(service *types.Service, opts types.Options) (<-chan *types.Response, error)
 }
 
-// Locator -
+// Locator is an interface defining a Service Discovery service
 type Locator interface {
 	Discover(signature *types.Signature) (*types.Service, error)
 }
 
-// LogAdapter -
+// LogAdapter is an interface defining a Logging service
 type LogAdapter interface {
 	Log(service *types.Service, message string)
 }
 
-// TraceAdapter -
+// TraceAdapter is an interface defining a Tracing service
 type TraceAdapter interface {
 	Trace(service *types.Service)
 }
@@ -171,7 +171,7 @@ func (d *Discover) discover(signature string) (*types.Service, error) {
 	return d.Discover(sig)
 }
 
-// Request - synchronous call
+// Request makes synchronous call through the FunctionAdapter
 func (d *Discover) Request(signature string, request types.Request, opts types.Options) (*types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
@@ -182,7 +182,7 @@ func (d *Discover) Request(signature string, request types.Request, opts types.O
 	return d.FunctionAdapter.Call(service, request, opts)
 }
 
-// Automate - calls an infrastructure script
+// Automate calls an infrastructure script through the AutomateAdapter
 func (d *Discover) Automate(signature string, request types.Request, opts types.Options) (*types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
@@ -193,7 +193,7 @@ func (d *Discover) Automate(signature string, request types.Request, opts types.
 	return d.AutomateAdapter.Execute(service, request, opts)
 }
 
-// Publish - publishes an asynchronous event
+// Publish publishes an asynchronous event through the PubsubAdapter
 func (d *Discover) Publish(signature string, request types.Request, opts types.Options) error {
 	service, err := d.discover(signature)
 	if err != nil {
@@ -204,7 +204,7 @@ func (d *Discover) Publish(signature string, request types.Request, opts types.O
 	return d.PubsubAdapter.Publish(service, request, opts)
 }
 
-// Subscribe - subscribe to an event
+// Subscribe subscribes to an event through the PubsubAdapter
 // Warning, not possible with SNS
 func (d *Discover) Subscribe(signature string, opts types.Options) (<-chan *types.Response, error) {
 	service, err := d.discover(signature)
@@ -216,7 +216,7 @@ func (d *Discover) Subscribe(signature string, opts types.Options) (<-chan *type
 	return d.PubsubAdapter.Subscribe(service, opts)
 }
 
-// Queue -
+// Queue queues a request through the QueueAdapter
 func (d *Discover) Queue(signature string, request types.Request, opts types.Options) (string, error) {
 	service, err := d.discover(signature)
 	if err != nil {
@@ -227,7 +227,7 @@ func (d *Discover) Queue(signature string, request types.Request, opts types.Opt
 	return d.QueueAdapter.Queue(service, request, opts)
 }
 
-// Listen -
+// Listen creates a listener channel through the QueueAdapter
 func (d *Discover) Listen(signature string, opts types.Options) (<-chan *types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
@@ -250,7 +250,8 @@ func (d *Discover) trace(service *types.Service) {
 	d.TraceAdapter.Trace(service)
 }
 
-// Call - potentially not needed, as the behavioural methods say
+// Call sends a request to the proper adapter depending on the service type.
+// (potentially not needed, as the behavioural methods say)
 func (d *Discover) Call(service types.ServiceRequest, opts types.Options) (*types.Response, error) {
 	switch service.Service.Type {
 	case "function", "lambda":

--- a/discovery.go
+++ b/discovery.go
@@ -117,24 +117,24 @@ func NewDiscovery(opts ...Option) *Discover {
 type QueueAdapter interface {
 
 	// Queue a message, return a token or message id
-	Queue(service *types.Service, request types.Request, opts types.Options) (string, error)
-	Listen(service *types.Service, opts types.Options) (<-chan *types.Response, error)
+	QueueWithOpts(service *types.Service, request types.Request, opts types.Options) (string, error)
+	ListenWithOpts(service *types.Service, opts types.Options) (<-chan *types.Response, error)
 }
 
 // FunctionAdapter is an interface defining a Serverless Functions service
 type FunctionAdapter interface {
-	Call(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
+	CallWithOpts(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
 }
 
 // AutomateAdapter is an interface defining a System Management service
 type AutomateAdapter interface {
-	Execute(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
+	ExecuteWithOpts(service *types.Service, request types.Request, opts types.Options) (*types.Response, error)
 }
 
 // PubsubAdapter is an interface defining a PubSub Messaging service
 type PubsubAdapter interface {
-	Publish(service *types.Service, request types.Request, opts types.Options) error
-	Subscribe(service *types.Service, opts types.Options) (<-chan *types.Response, error)
+	PublishWithOpts(service *types.Service, request types.Request, opts types.Options) error
+	SubscribeWithOpts(service *types.Service, opts types.Options) (<-chan *types.Response, error)
 }
 
 // Locator is an interface defining a Service Discovery service
@@ -171,71 +171,105 @@ func (d *Discover) discover(signature string) (*types.Service, error) {
 	return d.Discover(sig)
 }
 
+
 // Request makes synchronous call through the FunctionAdapter
-func (d *Discover) Request(signature string, request types.Request, opts types.Options) (*types.Response, error) {
+func (d *Discover) Request(signature string, request types.Request) (*types.Response, error) {
+	return d.RequestWithOpts(signature, request, types.Options{})
+}
+
+// RequestWithOpts makes synchronous call through the FunctionAdapter, with options
+func (d *Discover) RequestWithOpts(signature string, request types.Request, opts types.Options) (*types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
 		return nil, err
 	}
 	defer d.log(service, fmt.Sprintf("making a request to: %s", signature))
 	defer d.trace(service)
-	return d.FunctionAdapter.Call(service, request, opts)
+	return d.FunctionAdapter.CallWithOpts(service, request, opts)
 }
 
+
 // Automate calls an infrastructure script through the AutomateAdapter
-func (d *Discover) Automate(signature string, request types.Request, opts types.Options) (*types.Response, error) {
+func (d *Discover) Automate(signature string, request types.Request) (*types.Response, error) {
+	return d.AutomateWithOpts(signature, request, types.Options{})
+}
+
+// AutomateWithOpts calls an infrastructure script through the AutomateAdapter, with options
+func (d *Discover) AutomateWithOpts(signature string, request types.Request, opts types.Options) (*types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
 		return nil, err
 	}
 	defer d.log(service, fmt.Sprintf("running automation: %s", signature))
 	defer d.trace(service)
-	return d.AutomateAdapter.Execute(service, request, opts)
+	return d.AutomateAdapter.ExecuteWithOpts(service, request, opts)
 }
 
+
 // Publish publishes an asynchronous event through the PubsubAdapter
-func (d *Discover) Publish(signature string, request types.Request, opts types.Options) error {
+func (d *Discover) Publish(signature string, request types.Request) error {
+	return d.PublishWithOpts(signature, request, types.Options{})
+}
+
+// PublishWithOpts - publishes an asynchronous event through the PubsubAdapter, with options
+func (d *Discover) PublishWithOpts(signature string, request types.Request, opts types.Options) error {
 	service, err := d.discover(signature)
 	if err != nil {
 		return err
 	}
 	defer d.log(service, fmt.Sprintf("publishing event to: %s", signature))
 	defer d.trace(service)
-	return d.PubsubAdapter.Publish(service, request, opts)
+	return d.PubsubAdapter.PublishWithOpts(service, request, opts)
 }
 
 // Subscribe subscribes to an event through the PubsubAdapter
 // Warning, not possible with SNS
-func (d *Discover) Subscribe(signature string, opts types.Options) (<-chan *types.Response, error) {
+func (d *Discover) Subscribe(signature string) (<-chan *types.Response, error) {
+	return d.SubscribeWithOpts(signature, types.Options{})
+}
+
+// SubscribeWithOpts subscribes to an event through the PubsubAdapter, with options
+// Warning, not possible with SNS
+func (d *Discover) SubscribeWithOpts(signature string, opts types.Options) (<-chan *types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
 		return nil, err
 	}
 	defer d.log(service, fmt.Sprintf("subscribed to: %s", signature))
 	defer d.trace(service)
-	return d.PubsubAdapter.Subscribe(service, opts)
+	return d.PubsubAdapter.SubscribeWithOpts(service, opts)
 }
 
 // Queue queues a request through the QueueAdapter
-func (d *Discover) Queue(signature string, request types.Request, opts types.Options) (string, error) {
+func (d *Discover) Queue(signature string, request types.Request) (string, error) {
+	return d.QueueWithOpts(signature, request, types.Options{})
+}
+
+// QueueWithOpts queues a request through the QueueAdapter, with options
+func (d *Discover) QueueWithOpts(signature string, request types.Request, opts types.Options) (string, error) {
 	service, err := d.discover(signature)
 	if err != nil {
 		return "", err
 	}
 	defer d.log(service, fmt.Sprintf("queued message to: %s", signature))
 	defer d.trace(service)
-	return d.QueueAdapter.Queue(service, request, opts)
+	return d.QueueAdapter.QueueWithOpts(service, request, opts)
 }
 
 // Listen creates a listener channel through the QueueAdapter
-func (d *Discover) Listen(signature string, opts types.Options) (<-chan *types.Response, error) {
+func (d *Discover) Listen(signature string) (<-chan *types.Response, error) {
+	return d.ListenWithOpts(signature, types.Options{})
+}
+
+// ListenWithOpts creates a listener channel through the QueueAdapter, with options
+func (d *Discover) ListenWithOpts(signature string, opts types.Options) (<-chan *types.Response, error) {
 	service, err := d.discover(signature)
 	if err != nil {
 		return nil, err
 	}
 	defer d.log(service, fmt.Sprintf("listening to: %s", signature))
 	defer d.trace(service)
-	return d.QueueAdapter.Listen(service, opts)
+	return d.QueueAdapter.ListenWithOpts(service, opts)
 }
 
 // Logs the call that's made, using the given
@@ -253,20 +287,27 @@ func (d *Discover) trace(service *types.Service) {
 // Call sends a request to the proper adapter depending on the service type.
 // (potentially not needed, as the behavioural methods say)
 func (d *Discover) Call(service types.ServiceRequest, opts types.Options) (*types.Response, error) {
+	return d.CallWithOpts(service, types.Options{})
+}
+
+// CallWithOpts sends a request to the proper adapter depending on the service
+// type, with options.
+// (potentially not needed, as the behavioural methods say)
+func (d *Discover) CallWithOpts(service types.ServiceRequest, opts types.Options) (*types.Response, error) {
 	switch service.Service.Type {
 	case "function", "lambda":
-		return d.FunctionAdapter.Call(service.Service, service.Request, opts)
+		return d.FunctionAdapter.CallWithOpts(service.Service, service.Request, opts)
 	case "event", "pubsub":
-		return &types.Response{}, d.PubsubAdapter.Publish(service.Service, service.Request, opts)
+		return &types.Response{}, d.PubsubAdapter.PublishWithOpts(service.Service, service.Request, opts)
 	case "queue", "sqs":
-		token, err := d.QueueAdapter.Queue(service.Service, service.Request, opts)
+		token, err := d.QueueAdapter.QueueWithOpts(service.Service, service.Request, opts)
 		return &types.Response{
 			Body: []byte(token),
 		}, err
 	case "script", "ssm", "automation":
-		return d.AutomateAdapter.Execute(service.Service, service.Request, opts)
+		return d.AutomateAdapter.ExecuteWithOpts(service.Service, service.Request, opts)
 	default:
 		// @todo - potentially dangerous default option?
-		return d.FunctionAdapter.Call(service.Service, service.Request, opts)
+		return d.FunctionAdapter.CallWithOpts(service.Service, service.Request, opts)
 	}
 }

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -16,7 +16,7 @@ func (l *mockLocator) Discover(service *types.Signature) (*types.Service, error)
 
 type mockFunctionAdapter struct{}
 
-func (fa *mockFunctionAdapter) Call(
+func (fa *mockFunctionAdapter) CallWithOpts(
 	service *types.Service,
 	request types.Request,
 	opts types.Options,
@@ -28,7 +28,7 @@ type mockQueueAdapter struct {
 	messages chan *types.Response
 }
 
-func (qa *mockQueueAdapter) Queue(
+func (qa *mockQueueAdapter) QueueWithOpts(
 	service *types.Service,
 	request types.Request,
 	opts types.Options,
@@ -40,7 +40,7 @@ func (qa *mockQueueAdapter) Queue(
 	return "abc123", nil
 }
 
-func (qa *mockQueueAdapter) Listen(
+func (qa *mockQueueAdapter) ListenWithOpts(
 	service *types.Service,
 	options types.Options,
 ) (<-chan *types.Response, error) {
@@ -49,7 +49,7 @@ func (qa *mockQueueAdapter) Listen(
 
 type mockAutomateAdapter struct{}
 
-func (aa *mockAutomateAdapter) Execute(
+func (aa *mockAutomateAdapter) ExecuteWithOpts(
 	service *types.Service,
 	request types.Request,
 	opts types.Options,
@@ -59,7 +59,7 @@ func (aa *mockAutomateAdapter) Execute(
 
 type mockPubsubAdapter struct{}
 
-func (pa *mockPubsubAdapter) Publish(
+func (pa *mockPubsubAdapter) PublishWithOpts(
 	service *types.Service,
 	request types.Request,
 	opts types.Options,
@@ -67,7 +67,7 @@ func (pa *mockPubsubAdapter) Publish(
 	return nil
 }
 
-func (pa *mockPubsubAdapter) Subscribe(
+func (pa *mockPubsubAdapter) SubscribeWithOpts(
 	service *types.Service,
 	opts types.Options,
 ) (<-chan *types.Response, error) {
@@ -92,7 +92,7 @@ func TestCanCallRequest(t *testing.T) {
 	)
 	discover.Request("service->handler", types.Request{
 		Body: []byte(""),
-	}, nil)
+	})
 }
 
 func TestCanCallAutomate(t *testing.T) {
@@ -104,7 +104,7 @@ func TestCanCallAutomate(t *testing.T) {
 	)
 	_, err := discover.Automate("service->handler", types.Request{
 		Body: []byte(""),
-	}, nil)
+	})
 	assert.NoError(t, err)
 }
 
@@ -117,7 +117,7 @@ func TestCanCallPubSub(t *testing.T) {
 	)
 	err := discover.Publish("my-service->my-topic", types.Request{
 		Body: []byte(""),
-	}, nil)
+	})
 	assert.NoError(t, err)
 }
 
@@ -136,11 +136,11 @@ func TestCanCallQueue(t *testing.T) {
 	)
 	token, err := discover.Queue("my-service->my-queue", types.Request{
 		Body: val,
-	}, nil)
+	})
 	assert.NoError(t, err)
 	assert.Equal(t, token, "abc123")
 
-	messages, err := discover.Listen("my-service->my-queue", nil)
+	messages, err := discover.Listen("my-service->my-queue")
 	log.Println(messages)
 	assert.NoError(t, err)
 	assert.Equal(t, <-messages, response)

--- a/pkg/automate/ssm.go
+++ b/pkg/automate/ssm.go
@@ -21,7 +21,13 @@ func NewSSMAdapter(client *ssm.SSM) *SSMAdapter {
 
 // Execute executes an SSM document, with arguments and returns the execution ID
 // as the response body.
-func (sa *SSMAdapter) Execute(service *types.Service, request types.Request, opts types.Options) (*types.Response, error) {
+func (sa *SSMAdapter) Execute(service *types.Service, request types.Request) (*types.Response, error) {
+	return sa.ExecuteWithOpts(service, request, types.Options{})
+}
+
+// ExecuteWithOpts - executes an SSM document, with arguments and options.  Returns the execution ID
+// as the response body.
+func (sa *SSMAdapter) ExecuteWithOpts(service *types.Service, request types.Request, opts types.Options) (*types.Response, error) {
 	var args map[string][]*string
 	if err := json.Unmarshal(request.Body, &args); err != nil {
 		return nil, err

--- a/pkg/automate/ssm.go
+++ b/pkg/automate/ssm.go
@@ -9,17 +9,17 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 )
 
-// SSMAdapter -
+// SSMAdapter is a AutomateAdapter for AWS, using the Systems Manager service
 type SSMAdapter struct {
 	client *ssm.SSM
 }
 
-// NewSSMAdapter -
+// NewSSMAdapter creates a new instance of the SSMAdapter
 func NewSSMAdapter(client *ssm.SSM) *SSMAdapter {
 	return &SSMAdapter{client}
 }
 
-// Execute - executes an SSM document, with arguments and returns the execution ID
+// Execute executes an SSM document, with arguments and returns the execution ID
 // as the response body.
 func (sa *SSMAdapter) Execute(service *types.Service, request types.Request, opts types.Options) (*types.Response, error) {
 	var args map[string][]*string

--- a/pkg/function/lambda.go
+++ b/pkg/function/lambda.go
@@ -17,8 +17,14 @@ func NewLambdaAdapter(client *lambda.Lambda) *LambdaAdapter {
 	return &LambdaAdapter{client}
 }
 
+
 // Call exeutes a lambda function
-func (la *LambdaAdapter) Call(service *types.Service, request types.Request, opts types.Options) (*types.Response, error) {
+func (la *LambdaAdapter) Call(service *types.Service, request types.Request) (*types.Response, error) {
+	return la.CallWithOpts(service, request, types.Options{})
+}
+
+// CallWithOpts executes a lambda function, with options.
+func (la *LambdaAdapter) CallWithOpts(service *types.Service, request types.Request, opts types.Options) (*types.Response, error) {
 	input := &lambda.InvokeInput{
 		FunctionName: aws.String(service.Addr),
 		Payload:      request.Body,

--- a/pkg/function/lambda.go
+++ b/pkg/function/lambda.go
@@ -7,17 +7,17 @@ import (
 	"github.com/aws/aws-sdk-go/service/lambda"
 )
 
-// LambdaAdapter -
+// LambdaAdapter is an implentation of the FunctionAdapter using AWS Lambda
 type LambdaAdapter struct {
 	client *lambda.Lambda
 }
 
-// NewLambdaAdapter -
+// NewLambdaAdapter creates a new instance of the LambdaAdapter
 func NewLambdaAdapter(client *lambda.Lambda) *LambdaAdapter {
 	return &LambdaAdapter{client}
 }
 
-// Call a lambda function
+// Call exeutes a lambda function
 func (la *LambdaAdapter) Call(service *types.Service, request types.Request, opts types.Options) (*types.Response, error) {
 	input := &lambda.InvokeInput{
 		FunctionName: aws.String(service.Addr),

--- a/pkg/locator/cloudmap.go
+++ b/pkg/locator/cloudmap.go
@@ -7,17 +7,17 @@ import (
 	"github.com/peak-ai/ais-service-discovery-go/pkg/types"
 )
 
-// CloudmapLocator -
+// CloudmapLocator is an implementation of the Locator using AWS CloudMap
 type CloudmapLocator struct {
 	client *servicediscovery.ServiceDiscovery
 }
 
-// NewCloudmapLocator -
+// NewCloudmapLocator creates a new instance of CloudmapLocator
 func NewCloudmapLocator(client *servicediscovery.ServiceDiscovery) *CloudmapLocator {
 	return &CloudmapLocator{client}
 }
 
-// Discover a service
+// Discover searches for a service
 func (l *CloudmapLocator) Discover(service *types.Signature) (*types.Service, error) {
 	input := &servicediscovery.DiscoverInstancesInput{
 		NamespaceName: aws.String(service.Namespace),

--- a/pkg/logger/cloudwatch.go
+++ b/pkg/logger/cloudwatch.go
@@ -4,15 +4,15 @@ import (
 	"github.com/peak-ai/ais-service-discovery-go/pkg/types"
 )
 
-// NewCloudwatchLogger - 
+// NewCloudwatchLogger creates a new instance of the CloudwatchLogger
 func NewCloudwatchLogger() *CloudwatchLogger {
 	return &CloudwatchLogger{}
 }
 
-// CloudwatchLogger - 
+// CloudwatchLogger is an implementation of the LogAdapter using AWS CloudWatch
 type CloudwatchLogger struct {}
 
-// Log - 
+// Log logs the mesage
 func (cw *CloudwatchLogger) Log(service *types.Service, message string) {
 	return
 }

--- a/pkg/logger/stdout.go
+++ b/pkg/logger/stdout.go
@@ -14,15 +14,15 @@ func init() {
 	log.SetLevel(log.InfoLevel)
 }
 
-// STDOutLogger - logs formatted logs to std out.
+// STDOutLogger logs formatted logs to std out.
 type STDOutLogger struct{}
 
-// NewSTDOutAdapter -
+// NewSTDOutAdapter creates a new instance of the STDOutAdapter
 func NewSTDOutAdapter() *STDOutLogger {
 	return &STDOutLogger{}
 }
 
-// Log -
+// Log writes to std out
 func (so *STDOutLogger) Log(service *types.Service, message string) {
 	log.WithFields(log.Fields{
 		"service":  service.Name,

--- a/pkg/parser/addr_parser.go
+++ b/pkg/parser/addr_parser.go
@@ -5,9 +5,9 @@ import (
 	"strings"
 )
 
-// ParseAddr -
-// @todo - this is fairly crude, could be improved.
+// ParseAddr parse a string into a Signature
 func ParseAddr(signature string) (*types.Signature, error) {
+	// @todo - this is fairly crude, could be improved.
 	namespace := ""
 	service := ""
 	instance := ""

--- a/pkg/pubsub/sns.go
+++ b/pkg/pubsub/sns.go
@@ -19,8 +19,14 @@ func NewSNSAdapter(client *sns.SNS) *SNSAdapter {
 	return &SNSAdapter{client}
 }
 
+
 // Publish publishes an event to a queue
-func (sa *SNSAdapter) Publish(service *types.Service, request types.Request, opts types.Options) error {
+func (sa *SNSAdapter) Publish(service *types.Service, request types.Request) error {
+	return sa.PublishWithOpts(service, request, types.Options{})
+}
+
+// PublishWithOpts -
+func (sa *SNSAdapter) PublishWithOpts(service *types.Service, request types.Request, opts types.Options) error {
 	input := &sns.PublishInput{
 		Message:  aws.String(string(request.Body)),
 		TopicArn: aws.String(service.Addr),
@@ -29,9 +35,17 @@ func (sa *SNSAdapter) Publish(service *types.Service, request types.Request, opt
 	return err
 }
 
+
 // Subscribe is not implemented
 // (subscriptions are at a higher, none code level for AWS,
 // so we can't subscribe through code as such)
-func (sa *SNSAdapter) Subscribe(service *types.Service, opts types.Options) (<-chan *types.Response, error) {
+func (sa *SNSAdapter) Subscribe(service *types.Service) (<-chan *types.Response, error) {
+	return sa.SubscribeWithOpts(service, types.Options{})
+}
+
+// SubscribeWithOpts is not implemented
+// (subscriptions are at a higher, none code level for AWS,
+// so we can't subscribe through code as such)
+func (sa *SNSAdapter) SubscribeWithOpts(service *types.Service, opts types.Options) (<-chan *types.Response, error) {
 	return nil, errors.New("not valid for SNS")
 }

--- a/pkg/pubsub/sns.go
+++ b/pkg/pubsub/sns.go
@@ -9,17 +9,17 @@ import (
 	"github.com/aws/aws-sdk-go/service/sns"
 )
 
-// SNSAdapter -
+// SNSAdapter is an implementation of a PubsubAdapter using AWS SNS
 type SNSAdapter struct {
 	client *sns.SNS
 }
 
-// NewSNSAdapter instance
+// NewSNSAdapter creates a new SNSAdapter instance
 func NewSNSAdapter(client *sns.SNS) *SNSAdapter {
 	return &SNSAdapter{client}
 }
 
-// Publish -
+// Publish publishes an event to a queue
 func (sa *SNSAdapter) Publish(service *types.Service, request types.Request, opts types.Options) error {
 	input := &sns.PublishInput{
 		Message:  aws.String(string(request.Body)),
@@ -29,8 +29,9 @@ func (sa *SNSAdapter) Publish(service *types.Service, request types.Request, opt
 	return err
 }
 
-// Subscribe - subscriptions are at a higher, none code level for AWS,
-// so we can't subscribe through code as such.
+// Subscribe is not implemented
+// (subscriptions are at a higher, none code level for AWS,
+// so we can't subscribe through code as such)
 func (sa *SNSAdapter) Subscribe(service *types.Service, opts types.Options) (<-chan *types.Response, error) {
 	return nil, errors.New("not valid for SNS")
 }

--- a/pkg/queue/sqs.go
+++ b/pkg/queue/sqs.go
@@ -17,8 +17,14 @@ func NewSQSAdapter(client *sqs.SQS) *SQSAdapter {
 	return &SQSAdapter{client}
 }
 
+
 // Queue queues a message
-func (qa *SQSAdapter) Queue(service *types.Service, request types.Request, opts types.Options) (string, error) {
+func (qa *SQSAdapter) Queue(service *types.Service, request types.Request) (string, error) {
+	return qa.QueueWithOpts(service, request, types.Options{})
+}
+
+// QueueWithOpts queues a message, with options.
+func (qa *SQSAdapter) QueueWithOpts(service *types.Service, request types.Request, opts types.Options) (string, error) {
 	input := &sqs.SendMessageInput{
 		MessageBody: aws.String(string(request.Body)),
 		QueueUrl:    aws.String(service.Addr),
@@ -27,8 +33,14 @@ func (qa *SQSAdapter) Queue(service *types.Service, request types.Request, opts 
 	return *output.MessageId, err
 }
 
+
 // Listen listens for messages
-func (qa *SQSAdapter) Listen(service *types.Service, opts types.Options) (<-chan *types.Response, error) {
+func (qa *SQSAdapter) Listen(service *types.Service) (<-chan *types.Response, error) {
+	return qa.ListenWithOpts(service, types.Options{})
+}
+
+// ListenWithOpts listens for messages, with options
+func (qa *SQSAdapter) ListenWithOpts(service *types.Service, opts types.Options) (<-chan *types.Response, error) {
 	rchan := make(chan *types.Response)
 	input := &sqs.ReceiveMessageInput{
 		QueueUrl: aws.String(service.Addr),

--- a/pkg/queue/sqs.go
+++ b/pkg/queue/sqs.go
@@ -7,17 +7,17 @@ import (
 	"github.com/aws/aws-sdk-go/service/sqs"
 )
 
-// SQSAdapter -
+// SQSAdapter is an implementation of a QueueAdapter using AWS SQS
 type SQSAdapter struct {
 	client *sqs.SQS
 }
 
-// NewSQSAdapter -
+// NewSQSAdapter creates a new implementation of a SQSAdapter
 func NewSQSAdapter(client *sqs.SQS) *SQSAdapter {
 	return &SQSAdapter{client}
 }
 
-// Queue a message
+// Queue queues a message
 func (qa *SQSAdapter) Queue(service *types.Service, request types.Request, opts types.Options) (string, error) {
 	input := &sqs.SendMessageInput{
 		MessageBody: aws.String(string(request.Body)),
@@ -27,7 +27,7 @@ func (qa *SQSAdapter) Queue(service *types.Service, request types.Request, opts 
 	return *output.MessageId, err
 }
 
-// Listen for messages
+// Listen listens for messages
 func (qa *SQSAdapter) Listen(service *types.Service, opts types.Options) (<-chan *types.Response, error) {
 	rchan := make(chan *types.Response)
 	input := &sqs.ReceiveMessageInput{

--- a/pkg/tracer/xray.go
+++ b/pkg/tracer/xray.go
@@ -7,15 +7,15 @@ import (
 	"github.com/aws/aws-xray-sdk-go/xray"
 )
 
-// XrayTracer -
+// XrayTracer is an implementation of a TraceAdapter using AWS Xray
 type XrayTracer struct{}
 
-// NewXrayAdapter -
+// NewXrayAdapter creates a new instance of a XrayTracer
 func NewXrayAdapter() *XrayTracer {
 	return &XrayTracer{}
 }
 
-// Trace -
+// Trace traces an event
 func (xt *XrayTracer) Trace(service *types.Service) {
 	_, seg := xray.BeginSegment(context.Background(), service.Name)
 	seg.Close(nil)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,35 +1,35 @@
 package types
 
-// Service -
+// Service represents a service endpoint as returned from a Locator
 type Service struct {
 	Name string
 	Addr string
 	Type string
 }
 
-// Signature -
+// Signature represents a call to a service within a namespace
 type Signature struct {
 	Namespace string
 	Service   string
 	Instance   string
 }
 
-// ServiceRequest -
+// ServiceRequest represents a call to a service
 type ServiceRequest struct {
 	Service *Service
 	Request
 }
 
-// Request -
+// Request represents data to be sent to a service
 type Request struct {
 	Body []byte
 }
 
-// Response -
+// Response represents a response from a service
 type Response struct {
 	Body  []byte
 	Error error
 }
 
-// Options type
+// Options is a generic key-value map that can be passed to services
 type Options map[string]interface{}


### PR DESCRIPTION
See #1 

**Breaking Changes**

Any public method that allows options to be passed now has a default
call and a call that accepts `types.Options`.  For example
Request(service,request) and RequestWithOpts(service,request,opts).