### PR TITLE
FIXED cases for where queue url is referenced instead of arn

### DIFF
--- a/pkg/locator/cloudmap.go
+++ b/pkg/locator/cloudmap.go
@@ -1,6 +1,7 @@
 package locator
 
 import (
+	"errors"
 	aws "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/servicediscovery"
 
@@ -44,6 +45,10 @@ func (l *CloudmapLocator) Discover(service *types.Signature) (*types.Service, er
 	location := *instance.Attributes["arn"]
 	if location == "" {
 		location = *instance.Attributes["url"]
+	}
+
+	if location == "" {
+		return nil, errors.New("cannot find a url or arn associated with this service")
 	}
 
 	t := *instance.Attributes["type"]

--- a/pkg/locator/cloudmap.go
+++ b/pkg/locator/cloudmap.go
@@ -39,8 +39,13 @@ func (l *CloudmapLocator) Discover(service *types.Signature) (*types.Service, er
 
 
 	// @todo - 'arn' is AWS specific, consider a more
-	// generalisd term for this concept
+	// generalised term for this concept
+	// also, sometimes people use 'arn' other cases url 'url'.
 	location := *instance.Attributes["arn"]
+	if location == "" {
+		location = *instance.Attributes["url"]
+	}
+
 	t := *instance.Attributes["type"]
 
 	return &types.Service{


### PR DESCRIPTION
# Description
Initially we were using `arn` for AWS attributes, but queues, sometimes use `url` in various places. So need to check for both of those. 

I'm also returning an error if neither are found, preventing a null pointer exception in those cases.

## Steps to test
1. Create a go file, containing:
```go
func main() {
        signature, err := parser.ParseAddr("ais-latest.segment-generator->generator-queue")
	if err != nil {
		return nil, errors.Wrap(err, "service address is invalid")
	}

	log.Println(signature)

	q, err := sd.Discover(signature)
        log.Println(q)
        log.Println(err.Error())
}
```
2. It should resolve correctly and not throw an error.
3. Change the signature to `ais-latest.segment-generator->generator-queue-not-found`, it should throw an error, not a nil pointer.